### PR TITLE
Update Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # config.vm.box_check_update = false
 
   # MongoDB
-  config.vm.network "forwarded_port", guest: 27017, host: 27017
+  # config.vm.network "forwarded_port", guest: 27017, host: 27017
 
   config.vm.provision "shell", path: "automation/provision.sh"
 

--- a/automation/provision.sh
+++ b/automation/provision.sh
@@ -2,17 +2,10 @@ set -e
 set -x
 
 apt-get -qq update
-apt-get -qq install -y nginx git
-
-apt-get -qq install -y python-software-properties python g++ make
-add-apt-repository ppa:chris-lea/node.js
-apt-get -qq update
-apt-get -qq install -y nodejs
+apt-get -qq install -y python-software-properties python g++ make curl git
+curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
 
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
 apt-get -qq update
-apt-get -qq install -y mongodb-org
-
-cd /vagrant
-npm install
+apt-get -qq install -y nodejs mongodb-org

--- a/automation/provision.sh
+++ b/automation/provision.sh
@@ -9,3 +9,5 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
 echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
 apt-get -qq update
 apt-get -qq install -y nodejs mongodb-org
+
+echo "cd /vagrant" >> /home/vagrant/.bashrc


### PR DESCRIPTION
- update node to v0.12 in Vagrant.
- don't forward any ports -- they aren't necessary for development and we can avoid collisions